### PR TITLE
Fix type instability in chebinterp

### DIFF
--- a/src/interp.jl
+++ b/src/interp.jl
@@ -78,7 +78,7 @@ function droptol(coefs::Array{<:Any,N}, tol::Real) where {N}
     # compute the new size along each dimension by checking
     # the maximum index that cannot be dropped along each dim
     newsize = ntuple(Val{N}()) do dim
-        n = size(coefs, dim)
+        n::Int = size(coefs, dim)
         while n > 1
             r = ntuple(i -> i == dim ? (n:n) : (1:size(coefs,i)), Val{N}())
             any(c -> infnorm(c) ≥ abstol, @view coefs[CartesianIndices(r)]) && break
@@ -86,7 +86,7 @@ function droptol(coefs::Array{<:Any,N}, tol::Real) where {N}
         end
         n
     end
-    return coefs[CartesianIndices(map(n -> 1:n, newsize))]
+    return coefs[CartesianIndices(map(m -> 1:m, newsize))]
 end
 
 function chebinterp(vals::AbstractArray{<:Any,N}, lb::SVector{N}, ub::SVector{N}; tol::Real=epsvals(vals)) where {N}

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -78,9 +78,9 @@ function droptol(coefs::Array{<:Any,N}, tol::Real) where {N}
     # compute the new size along each dimension by checking
     # the maximum index that cannot be dropped along each dim
     newsize = ntuple(Val{N}()) do dim
-        n::Int = size(coefs, dim)
+        n = size(coefs, dim)
         while n > 1
-            r = ntuple(i -> i == dim ? (n:n) : (1:size(coefs,i)), Val{N}())
+            r = let n=n; ntuple(i -> i == dim ? (n:n) : (1:size(coefs,i)), Val{N}()); end
             any(c -> infnorm(c) ≥ abstol, @view coefs[CartesianIndices(r)]) && break
             n -= 1
         end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -86,7 +86,7 @@ function droptol(coefs::Array{<:Any,N}, tol::Real) where {N}
         end
         n
     end
-    return coefs[CartesianIndices(map(m -> 1:m, newsize))]
+    return coefs[CartesianIndices(map(n -> 1:n, newsize))]
 end
 
 function chebinterp(vals::AbstractArray{<:Any,N}, lb::SVector{N}, ub::SVector{N}; tol::Real=epsvals(vals)) where {N}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,3 +149,8 @@ end
     @test interp([0.1,0.22]) ≈ 3.2*cos(0.55)
     @test chebgradient(interp, [0.1,0.2])[2] == [2*cos(0.55), 0]
 end
+
+@testset "inference" begin
+    @inferred FastChebInterp.droptol(rand(5,5), 0.0)
+    @inferred chebinterp(rand(5,5), (0,0), (1,1))
+end


### PR DESCRIPTION
I noticed a type instability in `droptol` due to a variable in a closure modified in a loop that could be fixed with a type annotation.