### PR TITLE
Avoid errors in domain bounds check by checking before the transformation

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -61,8 +61,8 @@ end
 Evaluate the Chebyshev polynomial given by `interp` at the point `x`.
 """
 @fastmath function (interp::ChebPoly{N})(x::SVector{N,<:Real}) where {N}
+    all(interp.lb .≤ x .≤ interp.ub) || throw(ArgumentError("$x not in domain $(interp.lb) to $(interp.ub)"))
     x0 = @. (x - interp.lb) * 2 / (interp.ub - interp.lb) - 1
-    all(abs.(x0) .≤ 1) || throw(ArgumentError("$x not in domain $(interp.lb) to $(interp.ub)"))
     return evaluate(x0, interp.coefs, Val{N}(), 1, length(interp.coefs))
 end
 
@@ -145,8 +145,8 @@ giving the derivatives of each component.  If `v` is a scalar, then `J`
 is a 1-row matrix; in this case you may wish to call `chebgradient` instead.
 """
 function chebjacobian(c::ChebPoly{N}, x::SVector{N,<:Real}) where {N}
+    all(c.lb .≤ x .≤ c.ub) || throw(ArgumentError("$x not in domain $(c.lb) to $(c.ub)"))
     x0 = @. (x - c.lb) * 2 / (c.ub - c.lb) - 1
-    all(abs.(x0) .≤ 1) || throw(ArgumentError("$x not in domain $(c.lb) to $(c.ub)"))
     v, J = Jevaluate(x0, c.coefs, Val{N}(), 1, length(c.coefs))
     return v, J .* 2 ./ (c.ub .- c.lb)'
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,3 +169,11 @@ end
     @inferred FastChebInterp.droptol(rand(5,5), 0.0)
     @inferred chebinterp(rand(5,5), (0,0), (1,1))
 end
+
+# https://github.com/JuliaMath/FastChebInterp.jl/issues/36
+@testset "boundscheck sensitivity with fastmath" begin
+    x = chebpoints(50, 1.0, 100.0)
+    c = chebinterp(sin.(x), 1.0, 100.0)
+    @test all([c(100.0)] .== map(c, [100.0]))
+    @test all([c(100.0)] .≈  c.([100.0]))
+end


### PR DESCRIPTION
I propose this as a fix for https://github.com/JuliaMath/FastChebInterp.jl/issues/36. Do you think there is a better way to handle this?